### PR TITLE
Update SourceSpans, using existing spans

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -651,9 +651,7 @@ blockStmt =
           return (LocalVars (startLoc, endLoc) m t vds, endLoc)
       )
     <|> do
-      startLoc <- getLocation
-      (s, endLoc) <- stmt
-      return (BlockStmt (startLoc, endLoc) s, endLoc)
+      mapFst BlockStmt <$> stmt
 
 stmt :: P (Stmt Parsed, Location)
 stmt = ifStmt <|> whileStmt <|> forStmt <|> labeledStmt <|> stmtNoTrail
@@ -1446,19 +1444,20 @@ arrayCreation = do
 
 literal :: P (Literal, Location)
 literal = do
-  loc <- getEndLoc
+  startLoc <- getLocation
+  endLoc <- getEndLoc
   lit <-
     javaToken $ \case
-      IntTok i -> Just (Int i)
-      LongTok l -> Just (Word l)
-      DoubleTok d -> Just (Double d)
-      FloatTok f -> Just (Float f)
-      CharTok c -> Just (Char c)
-      StringTok s -> Just (String s)
-      BoolTok b -> Just (Boolean b)
-      NullTok -> Just Null
+      IntTok i -> Just (Int (startLoc, endLoc) i)
+      LongTok l -> Just (Word (startLoc, endLoc) l)
+      DoubleTok d -> Just (Double (startLoc, endLoc) d)
+      FloatTok f -> Just (Float (startLoc, endLoc) f)
+      CharTok c -> Just (Char (startLoc, endLoc) c)
+      StringTok s -> Just (String (startLoc, endLoc) s)
+      BoolTok b -> Just (Boolean (startLoc, endLoc) b)
+      NullTok -> Just (Null (startLoc, endLoc))
       _ -> Nothing
-  return (lit, loc)
+  return (lit, endLoc)
 
 -- Operators
 

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -242,7 +242,7 @@ instance PrettyExtension p => Pretty (Block p) where
   prettyPrec p (Block stmts) = braceBlock $ map (prettyPrec p) stmts
 
 instance PrettyExtension p => Pretty (BlockStmt p) where
-  prettyPrec p (BlockStmt _ stmt) = prettyPrec p stmt
+  prettyPrec p (BlockStmt stmt) = prettyPrec p stmt
   prettyPrec p (LocalClass cd) = prettyPrec p cd
   prettyPrec p (LocalVars _ mods t vds) =
     hsep (map (prettyPrec p) mods)
@@ -437,14 +437,14 @@ instance PrettyExtension p => Pretty (LambdaExpression p) where
   prettyPrec p (LambdaBlock block) = prettyPrec p block
 
 instance Pretty Literal where
-  prettyPrec _ (Int i) = text (show i)
-  prettyPrec _ (Word i) = text (show i) <> char 'L'
-  prettyPrec _ (Float f) = text (show f) <> char 'F'
-  prettyPrec _ (Double d) = text (show d)
-  prettyPrec _ (Boolean b) = text . map toLower $ show b
-  prettyPrec _ (Char c) = quotes $ text (escapeChar c)
-  prettyPrec _ (String s) = doubleQuotes $ text (concatMap escapeString s)
-  prettyPrec _ Null = text "null"
+  prettyPrec _ (Int _ i) = text (show i)
+  prettyPrec _ (Word _ i) = text (show i) <> char 'L'
+  prettyPrec _ (Float _ f) = text (show f) <> char 'F'
+  prettyPrec _ (Double _ d) = text (show d)
+  prettyPrec _ (Boolean _ b) = text . map toLower $ show b
+  prettyPrec _ (Char _ c) = quotes $ text (escapeChar c)
+  prettyPrec _ (String _ s) = doubleQuotes $ text (concatMap escapeString s)
+  prettyPrec _ (Null _) = text "null"
 
 instance Pretty Op where
   prettyPrec _ op = text $ case op of

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -310,6 +310,10 @@ instance EqualityExtension p => Equality (Decl p) where
     b1 == b2 && eq opt bl1 bl2
   eq _ _ _ = False
 
+instance ShowExtension p => Located (Decl p) where
+  sourceSpan (MemberDecl md) = sourceSpan md
+  sourceSpan d = error ("No SourceSpan implemented for Declaration: " ++ show d)
+
 -- | A class or interface member can be an inner class or interface, a field or
 --   constant, or a method or constructor. An interface may only have as members
 --   constants (not fields), abstract methods, and no constructors.
@@ -415,6 +419,10 @@ instance EqualityExtension p => Equality (VarInit p) where
   eq opt (InitArray ai1) (InitArray ai2) =
     eq opt ai1 ai2
   eq _ _ _ = False
+
+instance ShowExtension p => Located (VarInit p) where
+  sourceSpan (InitExp e) = sourceSpan e
+  sourceSpan vi = error ("No SourceSpan implemented for VarInit: " ++ show vi)
 
 -- | A formal parameter in method declaration. The last parameter
 --   for a given declaration may be marked as variable arity,
@@ -607,6 +615,10 @@ instance EqualityExtension p => Equality (ElementValue p) where
     eq opt a1 a2
   eq _ _ _ = False
 
+instance ShowExtension p => Located (ElementValue p) where
+  sourceSpan (EVVal vi) = sourceSpan vi
+  sourceSpan (EVAnn ann) = sourceSpan ann
+
 -----------------------------------------------------------------------
 -- Statements
 
@@ -628,7 +640,7 @@ instance EqualityExtension p => Equality (Block p) where
 -- | A block statement is either a normal statement, a local
 --   class declaration or a local variable declaration.
 data BlockStmt p
-  = BlockStmt SourceSpan (Stmt p)
+  = BlockStmt (Stmt p)
   | LocalClass (ClassDecl p)
   | LocalVars SourceSpan [Modifier p] Type [VarDecl p]
   deriving (Typeable, Generic)
@@ -640,16 +652,16 @@ deriving instance ReadExtension p => Read (BlockStmt p)
 deriving instance DataExtension p => Data (BlockStmt p)
 
 instance EqualityExtension p => Equality (BlockStmt p) where
-  eq opt (BlockStmt s1 stmt1) (BlockStmt s2 stmt2) =
-    eq opt s1 s2 && eq opt stmt1 stmt2
+  eq opt (BlockStmt stmt1) (BlockStmt stmt2) =
+    eq opt stmt1 stmt2
   eq opt (LocalClass cd1) (LocalClass cd2) =
     eq opt cd1 cd2
   eq opt (LocalVars s1 ms1 t1 vds1) (LocalVars s2 ms2 t2 vds2) =
     eq opt s1 s2 && eq opt ms1 ms2 && eq opt t1 t2 && eq opt vds1 vds2
   eq _ _ _ = False
 
-instance Located (BlockStmt p) where
-  sourceSpan (BlockStmt s _) = s
+instance ShowExtension p => Located (BlockStmt p) where
+  sourceSpan (BlockStmt s) = sourceSpan s
   sourceSpan (LocalClass cd) = sourceSpan cd
   sourceSpan (LocalVars s _ _ _) = s
 
@@ -794,6 +806,10 @@ instance EqualityExtension p => Equality (TryResource p) where
   eq opt (TryResourceQualAccess fa1) (TryResourceQualAccess fa2) =
     eq opt fa1 fa2
   eq _ _ _ = False
+
+instance ShowExtension p => Located (TryResource p) where
+  sourceSpan (TryResourceVarAccess i) = sourceSpan i
+  sourceSpan tr = error ("No SourceSpan implemented for Try Resource: " ++ show tr)
 
 data ResourceDecl p
   = ResourceDecl [Modifier p] Type VarDeclId (VarInit p)
@@ -1053,6 +1069,7 @@ instance EqualityExtension p => Equality (Exp p) where
   eq _ _ _ = False
 
 instance ShowExtension p => Located (Exp p) where
+  sourceSpan (Lit l) = sourceSpan l
   sourceSpan (ExpName n) = sourceSpan n
   sourceSpan (PostIncrement s _) = s
   sourceSpan (PostDecrement s _) = s

--- a/Language/Java/Syntax/Exp.hs
+++ b/Language/Java/Syntax/Exp.hs
@@ -5,30 +5,49 @@ module Language.Java.Syntax.Exp where
 
 import Data.Data
 import GHC.Generics (Generic)
+import Language.Java.SourceSpan (Located (..), SourceSpan)
 import Language.Java.Syntax.Equality (Equality (..))
 
 -- | A literal denotes a fixed, unchanging value.
 data Literal
-  = Int Integer
-  | Word Integer
-  | Float Double
-  | Double Double
-  | Boolean Bool
-  | Char Char
-  | String String
-  | Null
+  = Int SourceSpan Integer
+  | Word SourceSpan Integer
+  | Float SourceSpan Double
+  | Double SourceSpan Double
+  | Boolean SourceSpan Bool
+  | Char SourceSpan Char
+  | String SourceSpan String
+  | Null SourceSpan
   deriving (Show, Read, Typeable, Generic, Data)
 
 instance Equality Literal where
-  eq _ (Int n1) (Int n2) = n1 == n2
-  eq _ (Word n1) (Word n2) = n1 == n2
-  eq _ (Float x1) (Float x2) = x1 == x2
-  eq _ (Double x1) (Double x2) = x1 == x2
-  eq _ (Boolean b1) (Boolean b2) = b1 == b2
-  eq _ (Char c1) (Char c2) = c1 == c2
-  eq _ (String str1) (String str2) = str1 == str2
-  eq _ Null Null = True
+  eq opt (Int s1 n1) (Int s2 n2) =
+    eq opt s1 s2 && n1 == n2
+  eq opt (Word s1 n1) (Word s2 n2) =
+    eq opt s1 s2 && n1 == n2
+  eq opt (Float s1 x1) (Float s2 x2) =
+    eq opt s1 s2 && x1 == x2
+  eq opt (Double s1 x1) (Double s2 x2) =
+    eq opt s1 s2 && x1 == x2
+  eq opt (Boolean s1 b1) (Boolean s2 b2) =
+    eq opt s1 s2 && b1 == b2
+  eq opt (Char s1 c1) (Char s2 c2) =
+    eq opt s1 s2 && c1 == c2
+  eq opt (String s1 str1) (String s2 str2) =
+    eq opt s1 s2 && str1 == str2
+  eq opt (Null s1) (Null s2) =
+    eq opt s1 s2
   eq _ _ _ = False
+
+instance Located Literal where
+  sourceSpan (Int s _) = s
+  sourceSpan (Word s _) = s
+  sourceSpan (Float s _) = s
+  sourceSpan (Double s _) = s
+  sourceSpan (Boolean s _) = s
+  sourceSpan (Char s _) = s
+  sourceSpan (String s _) = s
+  sourceSpan (Null s) = s
 
 -- | A binary infix operator.
 data Op

--- a/Language/Java/Transformer.hs
+++ b/Language/Java/Transformer.hs
@@ -284,7 +284,7 @@ instance Transform VarInit where
   analyze scope (InitArray arrayInit) = InitArray (analyze scope arrayInit)
 
 instance Transform BlockStmt where
-  analyze scope (BlockStmt srcspan stmt) = BlockStmt srcspan (analyze scope stmt)
+  analyze scope (BlockStmt stmt) = BlockStmt (analyze scope stmt)
   analyze scope (LocalClass classDecl) = LocalClass (analyze scope classDecl)
   analyze scope (LocalVars srcspan modifiers type_ varDecls) =
     LocalVars


### PR DESCRIPTION
Vorrangig wurden für `Literal` die Spans hinzugefügt und bisherige Spans wurden dahingehend überprüft ob sie vereinfacht werden können, indem vorahndene Spans einfach wiederverwendet werden.


Ich denke, auf lange Sicht wäre es an sich sinnvoller, die SourceSpans nicht mehr einzeln als Argument der Konstruktoren anzugeben, sondern als Typ mit dem AST-Typ zu verpacken.